### PR TITLE
Suggest to change hse_finite so that the number of infected animals is rounded to integer

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,2 +1,4 @@
 Makefile
 .travis.yml
+^.*\.Rproj$
+^\.Rproj\.user$

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .Rhistory
+.Rproj.user
+*.Rproj

--- a/R/herd_se.R
+++ b/R/herd_se.R
@@ -61,7 +61,7 @@ hse_finite <- function(id,
 
     A <- 1 - (n_tested * test_Se / N)
 
-    B <- max(round(dp * N), 1)
+    B <- pmax(round(dp * N), 1)
 
     df <- as.data.frame(1 - tapply(A ^ B, INDEX = id, FUN = "prod"))
 

--- a/R/herd_se.R
+++ b/R/herd_se.R
@@ -61,7 +61,7 @@ hse_finite <- function(id,
 
     A <- 1 - (n_tested * test_Se / N)
 
-    B <- dp * N
+    B <- max(round(dp * N), 1)
 
     df <- as.data.frame(1 - tapply(A ^ B, INDEX = id, FUN = "prod"))
 


### PR DESCRIPTION
When calculating number of positive animals there was nu rounding of number of animals to integer.  In small herds with small prevalences this implies that there are less than one positive animal in a herd. For example design prevalence og 5% in a herd with ten animals gives an expected number of positive animals of 0.5. 
I suggest to round to nearest integer (round) but so that there is at least one infeced animal.
Another option is to include a parameter for chosing rounding, for eaxample rounding = c("none", "ceiling", "round", "floor") where 
none would be like it is now
ceiling would be like in package Rsurveillance
round would be my preference
floor would be more concervative